### PR TITLE
feat: allow grouping tasks

### DIFF
--- a/app.js
+++ b/app.js
@@ -35,6 +35,7 @@ const KEYS = {
   todos: "startpage.todos.v1",
   events: "startpage.events.v1",
   settings: "startpage.settings.v1",
+  todoGroups: "startpage.todoGroups.v1",
 };
 
 /* ====== Background animation toggle ====== */
@@ -114,6 +115,7 @@ window.addEventListener("keydown", (e) => {
 
 /* ====== To-do ====== */
 let todos = store.get(KEYS.todos, []);
+let groupState = store.get(KEYS.todoGroups, {});
 const listEl = $("#todoList");
 const emptyEl = $("#todoEmpty");
 
@@ -140,11 +142,18 @@ function renderTodos() {
       if (group) {
         const heading = document.createElement("li");
         heading.className = "todo-group";
-        heading.textContent = group;
+        heading.dataset.group = group;
+        heading.textContent = (groupState[group] ? "\u25B6 " : "\u25BC ") + group;
+        heading.addEventListener("click", () => {
+          groupState[group] = !groupState[group];
+          store.set(KEYS.todoGroups, groupState);
+          renderTodos();
+        });
         listEl.appendChild(heading);
       }
       currentGroup = group;
     }
+    if (group && groupState[group]) continue;
     const li = document.createElement("li");
     li.className = "todo" + (t.done ? " done" : "");
     li.draggable = true;

--- a/app.js
+++ b/app.js
@@ -125,14 +125,26 @@ function renderTodos() {
   } else {
     emptyEl.hidden = true;
   }
-  const order = { 0: 0, 1: 1, 2: 2, 3: 3 };
   const sorted = [...todos].sort((a, b) => {
+    if ((a.group || "") !== (b.group || ""))
+      return (a.group || "").localeCompare(b.group || "");
     if (a.done !== b.done) return a.done ? 1 : -1;
     if ((b.priority || 1) !== (a.priority || 1))
       return (b.priority || 1) - (a.priority || 1);
     return (a.due || "9999-12-31").localeCompare(b.due || "9999-12-31");
   });
+  let currentGroup;
   for (const t of sorted) {
+    const group = t.group || "";
+    if (group !== currentGroup) {
+      if (group) {
+        const heading = document.createElement("li");
+        heading.className = "todo-group";
+        heading.textContent = group;
+        listEl.appendChild(heading);
+      }
+      currentGroup = group;
+    }
     const li = document.createElement("li");
     li.className = "todo" + (t.done ? " done" : "");
     li.draggable = true;
@@ -211,20 +223,37 @@ function renderTodos() {
     else listEl.insertBefore(dragging, after);
   });
 }
-function addTodo(text, due) {
-  todos.push({ id: toKey(), text, due: due || null, done: false, priority: 1 });
+function addTodo(text, due, group) {
+  todos.push({
+    id: toKey(),
+    text,
+    due: due || null,
+    group: group || null,
+    done: false,
+    priority: 1,
+  });
   store.set(KEYS.todos, todos);
   renderTodos();
 }
 $("#todoAddBtn").addEventListener("click", () => {
   const text = $("#todoText").value.trim();
   if (!text) return;
-  addTodo(text, $("#todoDate").value || null);
+  addTodo(
+    text,
+    $("#todoDate").value || null,
+    $("#todoGroup").value.trim() || null
+  );
   $("#todoText").value = "";
   $("#todoDate").value = "";
+  $("#todoGroup").value = "";
   $("#todoText").focus();
 });
 $("#todoText").addEventListener("keydown", (e) => {
+  if (e.key === "Enter") {
+    $("#todoAddBtn").click();
+  }
+});
+$("#todoGroup").addEventListener("keydown", (e) => {
   if (e.key === "Enter") {
     $("#todoAddBtn").click();
   }

--- a/index.html
+++ b/index.html
@@ -78,6 +78,7 @@
           <div id="todoAdd">
             <input id="todoText" placeholder="Add a task… (Enter)" />
             <input id="todoDate" type="date" />
+            <input id="todoGroup" placeholder="Group (optional)" />
             <button id="todoAddBtn" title="Add task">Add</button>
           </div>
           <ul id="todoList" aria-live="polite"></ul>

--- a/styles.css
+++ b/styles.css
@@ -230,6 +230,7 @@ main {
     grid-template-columns: 1fr;
   }
   #todoDate,
+  #todoGroup,
   #todoAdd button {
     width: 100%;
   }
@@ -293,12 +294,13 @@ section.panel header .actions {
 }
 #todoAdd {
   display: grid;
-  grid-template-columns: 1fr 120px 44px;
+  grid-template-columns: 1fr 120px 120px 44px;
   gap: 8px;
   margin-bottom: 10px;
 }
 #todoText,
-#todoDate {
+#todoDate,
+#todoGroup {
   background: #0f1320;
   color: var(--text);
   border: 1px solid var(--border);
@@ -323,6 +325,10 @@ section.panel header .actions {
   padding: 0;
   display: grid;
   gap: 6px;
+}
+.todo-group {
+  font-weight: 600;
+  margin-top: 10px;
 }
 .todo {
   display: grid;

--- a/styles.css
+++ b/styles.css
@@ -329,6 +329,7 @@ section.panel header .actions {
 .todo-group {
   font-weight: 600;
   margin-top: 10px;
+  cursor: pointer;
 }
 .todo {
   display: grid;


### PR DESCRIPTION
## Summary
- allow adding tasks to named groups
- display grouped tasks with headers
- style new group input and headings

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68c523bd6f1c8328ab0208fc1016be7c